### PR TITLE
Support lazy broadcasting with tridiagonal

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LazyBandedMatrices"
 uuid = "d7e5e226-e90b-4449-9968-0f923699bf6f"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.10"
+version = "0.10.1"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -688,8 +688,12 @@ bandwidths(::SymTridiagonal) = (1,1)
 bandwidths(::Tridiagonal) = (1,1)
 
 
-Base.BroadcastStyle(::Type{SymTridiagonal{T,DV,EV}}) where {T,DV,EV} = StructuredMatrixStyle{LinearAlgebra.SymTridiagonal{T,DV}}()
-Base.BroadcastStyle(::Type{Tridiagonal{T,DL,D,DU}}) where {T,DL,D,DU} = StructuredMatrixStyle{LinearAlgebra.Tridiagonal{T,D}}()
+Base.BroadcastStyle(::Type{SymTridiagonal{T,DV,EV}}) where {T,DV,EV} =
+    structuredmatrix_broadcaststyle(SymTridiagonal, Base.Broadcast.result_style(Base.BroadcastStyle(DV), Base.BroadcastStyle(EV)))
+Base.BroadcastStyle(::Type{Tridiagonal{T,DL,D,DU}}) where {T,DL,D,DU} =
+    structuredmatrix_broadcaststyle(Tridiagonal, Base.Broadcast.result_style(Base.BroadcastStyle(DL), Base.Broadcast.result_style(Base.BroadcastStyle(D), Base.BroadcastStyle(DU))))
+structuredmatrix_broadcaststyle(Typ, ::LazyArrayStyle) = LazyArrayStyle{2}()
+structuredmatrix_broadcaststyle(Typ, _) = StructuredMatrixStyle{Typ}()
 
 
 convert(::Type{LinearAlgebra.Tridiagonal}, B::Tridiagonal) = LinearAlgebra.Tridiagonal(B.dl, B.d, B.du)

--- a/test/test_tridiag.jl
+++ b/test/test_tridiag.jl
@@ -461,6 +461,10 @@ import LazyBandedMatrices: SymTridiagonal, Tridiagonal
         B = randn(5,5)
         @test SymTridiagonal(ApplyArray(*, A, B)) ≈ SymTridiagonal(A*B)
     end
+
+    @testset "Broadcast" begin
+        
+    end
 end # testset
 
 end # module TestTridiagonal

--- a/test/test_tridiag.jl
+++ b/test/test_tridiag.jl
@@ -463,7 +463,15 @@ import LazyBandedMatrices: SymTridiagonal, Tridiagonal
     end
 
     @testset "Broadcast" begin
-        
+        A = SymTridiagonal(Zeros(5), exp.(1:4))
+        @test 2 .+ A isa Matrix
+        B = SymTridiagonal(Zeros(5), BroadcastArray(exp, 1:4))
+        @test 2 .+ B isa BroadcastArray
+
+        C = Tridiagonal(exp.(1:4), Zeros(5), exp.(1:4))
+        @test 2 .+ C isa Matrix
+        D = Tridiagonal(BroadcastArray(exp, 1:4), Zeros(5), BroadcastArray(exp, 1:4))
+        @test 2 .+ D isa BroadcastArray
     end
 end # testset
 


### PR DESCRIPTION
Fixes https://github.com/JuliaApproximation/ClassicalOrthogonalPolynomials.jl/issues/181

```julia
julia> 1X^2 # never ends
((Int64) .* (ℵ₀×ℵ₀ LazyBandedMatrices.Tridiagonal{Float64, ApplyArray{Float64, 1, typeof(vcat), Tuple{Float64, BroadcastVector{Float64, typeof(/), Tuple{BroadcastVector{Float64, typeof(*), Tuple{InfiniteArrays.InfStepRange{Int64, Int64}, InfiniteArrays.InfStepRange{Float64, Float64}}}, BroadcastVector{Float64, typeof(*), Tuple{InfiniteArrays.InfStepRange{Float64, Float64}, InfiniteArrays.InfStepRange{Float64, Float64}}}}}}}, ApplyArray{Float64, 1, typeof(vcat), Tuple{Float64, BroadcastVector{Float64, typeof(/), Tuple{Float64, BroadcastVector{Float64, typeof(*), Tuple{InfiniteArrays.InfStepRange{Float64, Float64}, InfiniteArrays.InfStepRange{Float64, Float64}}}}}}}, BroadcastVector{Float64, typeof(/), Tuple{BroadcastVector{Float64, typeof(*), Tuple{InfiniteArrays.InfStepRange{Float64, Float64}, InfiniteArrays.InfStepRange{Float64, Float64}}}, BroadcastVector{Float64, typeof(*), Tuple{InfiniteArrays.InfStepRange{Float64, Float64}, InfiniteArrays.InfStepRange{Float64, Float64}}}}}} with indices OneToInf()×OneToInf()) with indices OneToInf()×OneToInf()) * (ℵ₀×ℵ₀ LazyBandedMatrices.Tridiagonal{Float64, ApplyArray{Float64, 1, typeof(vcat), Tuple{Float64, BroadcastVector{Float64, typeof(/), Tuple{BroadcastVector{Float64, typeof(*), Tuple{InfiniteArrays.InfStepRange{Int64, Int64}, InfiniteArrays.InfStepRange{Float64, Float64}}}, BroadcastVector{Float64, typeof(*), Tuple{InfiniteArrays.InfStepRange{Float64, Float64}, InfiniteArrays.InfStepRange{Float64, Float64}}}}}}}, ApplyArray{Float64, 1, typeof(vcat), Tuple{Float64, BroadcastVector{Float64, typeof(/), Tuple{Float64, BroadcastVector{Float64, typeof(*), Tuple{InfiniteArrays.InfStepRange{Float64, Float64}, InfiniteArrays.InfStepRange{Float64, Float64}}}}}}}, BroadcastVector{Float64, typeof(/), Tuple{BroadcastVector{Float64, typeof(*), Tuple{InfiniteArrays.InfStepRange{Float64, Float64}, InfiniteArrays.InfStepRange{Float64, Float64}}}, BroadcastVector{Float64, typeof(*), Tuple{InfiniteArrays.InfStepRange{Float64, Float64}, InfiniteArrays.InfStepRange{Float64, Float64}}}}}} with indices OneToInf()×OneToInf()) with indices OneToInf()×OneToInf():
 0.279279   0.0460035  0.147964     ⋅           ⋅           ⋅           ⋅          …  
 0.0945626  0.52221    0.00953302  0.17828      ⋅           ⋅           ⋅             
 0.460035   0.014419   0.507445    0.00445979  0.194484     ⋅           ⋅             
  ⋅         0.361017   0.00597084  0.503819    0.00262417  0.204657     ⋅             
  ⋅          ⋅         0.326273    0.00328828  0.502339    0.00173681  0.211659       
  ⋅          ⋅          ⋅          0.308246    0.00208759  0.501584    0.00123697  …  
  ⋅          ⋅          ⋅           ⋅          0.297157    0.00144482  0.501145       
  ⋅          ⋅          ⋅           ⋅           ⋅          0.289633    0.00106001     
  ⋅          ⋅          ⋅           ⋅           ⋅           ⋅          0.284187       
 ⋮                                                         ⋮                       ⋱  
```