### PR TITLE
Don't interpolate array into ArgumentError

### DIFF
--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -441,8 +441,8 @@ bidiagonaluplo(A::Bidiagonal) = A.uplo
 
 
 diagonaldata(D::Bidiagonal) = D.dv
-supdiagonaldata(D::Bidiagonal) = D.uplo == 'U' ? D.ev : throw(ArgumentError("$D is lower-bidiagonal"))
-subdiagonaldata(D::Bidiagonal) = D.uplo == 'L' ? D.ev : throw(ArgumentError("$D is upper-bidiagonal"))
+supdiagonaldata(D::Bidiagonal) = D.uplo == 'U' ? D.ev : throw(ArgumentError("Array is lower-bidiagonal"))
+subdiagonaldata(D::Bidiagonal) = D.uplo == 'L' ? D.ev : throw(ArgumentError("Array is upper-bidiagonal"))
 
 permutedims(B::Bidiagonal) = Bidiagonal(B.dv, B.ev, B.uplo == 'U' ? 'L' : 'U')
 


### PR DESCRIPTION
For small matrices interpolating isn't awful,

```julia
ERROR: ArgumentError: 2×2 LazyBandedMatrices.Bidiagonal{Float64, Vector{Float64}, Vector{Float64}}:
 diag: 1.0  2.0
 sub: 3.0 is lower-bidiagonal
Stacktrace:
 [1] supdiagonaldata(D::LazyBandedMatrices.Bidiagonal{Float64, Vector{Float64}, Vector{Float64}})
   @ LazyBandedMatrices C:\Users\djv23\.julia\packages\LazyBandedMatrices\aQCdj\src\bidiag.jl:444
 [2] top-level scope
   @ REPL[17]:1
```

but for larger matrices it just prints a lot of unnecessary content. Where I encountered this was when accidentally using this method with an infinite matrix,

```julia
julia> using ClassicalOrthogonalPolynomials, ArrayLayouts

julia> R = Jacobi(1, 0) \ Jacobi(0, 0);

julia> ArrayLayouts.subdiagonaldata(R)
ERROR: OutOfMemoryError()
Stacktrace:
  [1] GenericMemory
    @ .\boot.jl:516 [inlined]
  [2] Array
    @ .\boot.jl:578 [inlined]
  [3] vcat(::UnitRange{Int64}, ::UnitRange{Int64})
    @ Base .\range.jl:1357
  [4] _print_matrix(io::IOBuffer, X::AbstractVecOrMat, pre::String, sep::String, post::String, hdots::String, vdots::String, ddots::String, hmod::Int64, vmod::Int64, rowsA::UnitRange{…}, colsA::InfiniteArrays.InfUnitRange{…})
    @ Base .\arrayshow.jl:203
  [5] print_matrix(io::IOBuffer, X::LinearAlgebra.Adjoint{…}, pre::String, sep::String, post::String, hdots::String, vdots::String, ddots::String, hmod::Int64, vmod::Int64)
    @ Base .\arrayshow.jl:171
  [6] print_matrix
    @ .\arrayshow.jl:171 [inlined]
  [7] show(io::IOBuffer, M::LazyBandedMatrices.Bidiagonal{…})
    @ LazyBandedMatrices C:\Users\djv23\.julia\packages\LazyBandedMatrices\aQCdj\src\bidiag.jl:201
  [8] print(io::IOBuffer, x::LazyBandedMatrices.Bidiagonal{…})
    @ Base .\strings\io.jl:35
  [9] print_to_string(::LazyBandedMatrices.Bidiagonal{…}, ::Vararg{…})
    @ Base .\strings\io.jl:148
 [10] string
    @ .\strings\io.jl:189 [inlined]
 [11] subdiagonaldata(D::LazyBandedMatrices.Bidiagonal{Float64, LazyArrays.BroadcastVector{…}, LazyArrays.BroadcastVector{…}})
    @ LazyBandedMatrices C:\Users\djv23\.julia\packages\LazyBandedMatrices\aQCdj\src\bidiag.jl:445
 [12] top-level scope
    @ REPL[21]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

which took a minute to debug initially since it hides the intended error
